### PR TITLE
feat(events): add PlayerJoinedMessage and PlayerQuitMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Chorus is licensed under the [Apache License 2.0](LICENSE).
 
 <!-- BADGES -->
 
-[minecraft_badge_url]: https://img.shields.io/badge/minecraft-26.30-black?style=flat-square
-[minecraft_url]: https://www.minecraft.net/en-us/article/minecraft-26-30-bedrock-changelog
-[protocol_badge_url]: https://img.shields.io/badge/protocol-v1001-white?style=flat-square
+[minecraft_badge_url]: https://img.shields.io/badge/minecraft-26.40-black?style=flat-square
+[minecraft_url]: https://www.minecraft.net/en-us/article/minecraft-26-40-bedrock-changelog
+[protocol_badge_url]: https://img.shields.io/badge/protocol-v2168-white?style=flat-square
 [protocol_url]: https://github.com/Mojang/bedrock-protocol-docs
 [rust_badge_url]: https://img.shields.io/badge/rust-2024-%23D34516?style=flat-square&logo=rust&logoColor=%23D34516&labelColor=white
 [rust_url]: https://rust-lang.org/

--- a/src/network/handler/mod.rs
+++ b/src/network/handler/mod.rs
@@ -6,7 +6,7 @@ use crate::network::handler::chunks::{handle_sub_chunk_request, send_pending_chu
 use crate::network::handler::handshake::handle_handshake;
 use crate::network::handler::inventory::{handle_inventory_packets, send_initial_inventory};
 use crate::network::handler::login::handle_login;
-use crate::network::handler::play::{broadcast_block_updates, handle_play, on_enter_play, on_quit};
+use crate::network::handler::play::{announce_join_quit, broadcast_block_updates, handle_play, on_enter_play, on_quit};
 use crate::network::handler::request::handle_request;
 use crate::network::handler::resource::handle_resource;
 use crate::network::handler::setup::{handle_setup, on_enter_setup};
@@ -45,7 +45,7 @@ impl Plugin for PacketHandlers {
                 (on_enter_setup, handle_setup).chain(),
                 (on_enter_play, send_initial_inventory, handle_play).chain(),
                 (handle_block_actions, update_block_breaking, handle_inventory_packets, dispatch_commands).chain(),
-                (broadcast_chat, on_quit, broadcast_message).chain(),
+                (broadcast_chat, on_quit, announce_join_quit, broadcast_message).chain(),
                 (update_chunk_order, send_pending_chunks, handle_sub_chunk_request).chain(),
                 (broadcast_block_updates, broadcast_level_events, broadcast_level_sounds).chain(),
             )

--- a/src/network/handler/play.rs
+++ b/src/network/handler/play.rs
@@ -18,16 +18,28 @@ use bedrock::protocol::v776::enums::AbilitiesIndex;
 use bedrock::protocol::v776::types::{SerializedAbilitiesData, SerializedAbilitiesLayer, SerializedLayer};
 use bedrock::protocol::v944::types::NetworkBlockPosition;
 use bedrock::protocol::v2168::enums::DataItemType;
-use bevy_ecs::message::{MessageReader, MessageWriter};
-use bevy_ecs::prelude::{Query, Res};
+use bevy_ecs::message::{Message, MessageReader, MessageWriter};
+use bevy_ecs::prelude::{Entity, Query, Res};
 use glam::{Vec2, Vec3};
 use tracing::{debug, info};
+
+#[derive(Message, Clone, Debug)]
+pub struct PlayerJoinedMessage {
+    pub entity: Entity,
+    pub name: String,
+}
+
+#[derive(Message, Clone, Debug)]
+pub struct PlayerQuitMessage {
+    pub entity: Entity,
+    pub name: String,
+}
 
 pub fn on_enter_play(
     mut sessions: Query<(&mut Session, &Player, &PlayerIdentity)>,
     commands: Res<CommandRegistry>,
     mut state_reader: MessageReader<SessionStateChangedMessage>,
-    mut broadcast_writer: MessageWriter<BroadcastMessage>,
+    mut join_writer: MessageWriter<PlayerJoinedMessage>,
 ) {
     for ev in state_reader.read() {
         if ev.to != SessionState::Play {
@@ -41,7 +53,10 @@ pub fn on_enter_play(
 
         info!("{} joined the game", identity.name());
 
-        broadcast_writer.write(BroadcastMessage::translate("§e%multiplayer.player.joined", vec![identity.name().to_string()]));
+        join_writer.write(PlayerJoinedMessage {
+            entity: ev.entity,
+            name: identity.name().to_string(),
+        });
 
         session.send(BedrockProtocol::AvailableCommandsPacket(commands.to_packet().into()));
 
@@ -120,15 +135,28 @@ pub fn on_enter_play(
     }
 }
 
-pub fn on_quit(sessions: Query<(&Session, &PlayerIdentity)>, mut broadcast_writer: MessageWriter<BroadcastMessage>) {
-    for (session, identity) in &sessions {
+pub fn on_quit(sessions: Query<(Entity, &Session, &PlayerIdentity)>, mut quit_writer: MessageWriter<PlayerQuitMessage>) {
+    for (entity, session, identity) in &sessions {
         if !session.is_closed() || session.get_state() != SessionState::Play {
             continue;
         }
 
         info!("{} left the game", identity.name());
 
-        broadcast_writer.write(BroadcastMessage::translate("§e%multiplayer.player.left", vec![identity.name().to_string()]));
+        quit_writer.write(PlayerQuitMessage {
+            entity,
+            name: identity.name().to_string(),
+        });
+    }
+}
+
+pub fn announce_join_quit(mut join_reader: MessageReader<PlayerJoinedMessage>, mut quit_reader: MessageReader<PlayerQuitMessage>, mut broadcast_writer: MessageWriter<BroadcastMessage>) {
+    for ev in join_reader.read() {
+        broadcast_writer.write(BroadcastMessage::translate("§e%multiplayer.player.joined", vec![ev.name.clone()]));
+    }
+
+    for ev in quit_reader.read() {
+        broadcast_writer.write(BroadcastMessage::translate("§e%multiplayer.player.left", vec![ev.name.clone()]));
     }
 }
 

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -4,6 +4,7 @@ use crate::level::{BlockUpdatedMessage, LevelEventMessage, LevelSoundMessage};
 use crate::network::BedrockProtocol;
 use crate::network::bandwidth::BandwidthTracker;
 use crate::network::handler::chat::{BroadcastMessage, PlayerChatMessage};
+use crate::network::handler::play::{PlayerJoinedMessage, PlayerQuitMessage};
 use crate::network::handler::{PacketHandlers, PacketReceivedMessage};
 use crate::network::login::auth::LoginAuthOIDC;
 use crate::network::session::Session;
@@ -39,6 +40,8 @@ impl Plugin for Network {
             .init_resource::<BandwidthTracker>()
             .add_message::<PacketReceivedMessage>()
             .add_message::<SessionStateChangedMessage>()
+            .add_message::<PlayerJoinedMessage>()
+            .add_message::<PlayerQuitMessage>()
             .add_message::<BlockUpdatedMessage>()
             .add_message::<PlayerChatMessage>()
             .add_message::<CommandRequestedMessage>()


### PR DESCRIPTION
## Summary

Introduces two new events, `PlayerJoinedMessage` and `PlayerQuitMessage`,
emitted from `on_enter_play` / `on_quit` instead of writing `BroadcastMessage`
directly. A new `announce_join_quit` system consumes them to produce the
chat-visible broadcast, so other systems can react to a player joining or
quitting without depending on chat at all.

This is a first step toward a broader gameplay event system (block break/place,
inventory transactions, entity damage, etc.) following the existing
`Message`/`MessageWriter`/`MessageReader` pattern already used for
`SessionStateChangedMessage`, `BlockUpdatedMessage`, and others.

## Related issues

<!-- Fixes/Closes: #<issue-number> if there's an open issue for this -->

## Type of change

- Feature

## Checklist

- [x] My code follows the project style (ran `cargo fmt`)
- [x] I ran `cargo clippy` and addressed warnings where appropriate
- [ ] I added tests for new behavior (not applicable - no test suite in this repo yet)
- [x] All CI checks pass
- [ ] I updated relevant documentation (not applicable)

## Test Plan

Ran the server locally, connected with a client, and verified the join/leave
chat broadcast still appears exactly as before (`§e%multiplayer.player.joined`
/ `%multiplayer.player.left`). Confirmed via `cargo check` that message
registration and system ordering compile cleanly.

## Notes for reviewers

The broadcast text/behavior is unchanged - this PR only splits the existing
inline logic into a producer (`on_enter_play`/`on_quit`) and a consumer
(`announce_join_quit`), following the co-location convention already used
for other messages in this codebase (see `level/mod.rs`, `handler/chat.rs`).