### PR TITLE
feat(events): expand event system (block, inventory, chat, command, movement, login, resource pack, form)

### DIFF
--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -13,6 +13,12 @@ pub struct CommandRequestedMessage {
     pub line: String,
 }
 
+#[derive(Message, Clone, Debug)]
+pub struct CommandPreprocessMessage {
+    pub entity: Entity,
+    pub line: String,
+}
+
 /// Exclusive so that a command can read the whole world. The sender needs the session and the
 /// player mutably, so both are taken out of the entity for the duration of the call and put back
 /// right after.

--- a/src/network/handler/block.rs
+++ b/src/network/handler/block.rs
@@ -15,8 +15,8 @@ use bedrock::protocol::v662::packets::LevelEventPacket;
 use bedrock::protocol::v766::enums::LevelEvent;
 use bedrock::protocol::v1001::packets::LevelSoundEventPacket;
 use bevy_ecs::change_detection::ResMut;
-use bevy_ecs::message::{MessageReader, MessageWriter};
-use bevy_ecs::prelude::Query;
+use bevy_ecs::message::{Message, MessageReader, MessageWriter};
+use bevy_ecs::prelude::{Entity, Query};
 use bevy_ecs::system::Res;
 use glam::{IVec3, Vec3};
 use tracing::debug;
@@ -35,6 +35,21 @@ struct BlockAction {
     face: i32,
 }
 
+#[derive(Message, Clone, Debug)]
+pub struct BlockBreakMessage {
+    pub entity: Entity,
+    pub position: IVec3,
+    pub block_id: i32,
+}
+
+#[derive(Message, Clone, Debug)]
+pub struct BlockPlaceMessage {
+    pub entity: Entity,
+    pub position: IVec3,
+    pub block_id: i32,
+    pub face: i32,
+}
+
 pub fn handle_block_actions(
     mut packet_reader: MessageReader<PacketReceivedMessage>,
     mut query: Query<(&Session, &PlayerEntity, &mut Player)>,
@@ -42,6 +57,8 @@ pub fn handle_block_actions(
     registry: Res<BlockRegistry>,
     mut event_writer: MessageWriter<LevelEventMessage>,
     mut block_writer: MessageWriter<BlockUpdatedMessage>,
+    mut break_writer: MessageWriter<BlockBreakMessage>,
+    mut place_writer: MessageWriter<BlockPlaceMessage>,
 ) {
     for ev in packet_reader.read() {
         let Ok((session, entity, mut player)) = query.get_mut(ev.entity) else {
@@ -74,10 +91,10 @@ pub fn handle_block_actions(
                 // read: the item use transaction it belongs to arrives in a packet bedrock-rs
                 // cannot decode yet
                 PlayerActionType::StartItemUseOn => {
-                    place_block(&action, entity, &player, &mut level, &registry, &mut block_writer);
+                    place_block(ev.entity, &action, entity, &player, &mut level, &registry, &mut block_writer, &mut place_writer);
                 }
                 PlayerActionType::PredictDestroyBlock | PlayerActionType::CreativeDestroyBlock => {
-                    break_block(&action, entity, &mut player, &mut level, &registry, &mut event_writer, &mut block_writer);
+                    break_block(ev.entity, &action, entity, &mut player, &mut level, &registry, &mut event_writer, &mut block_writer, &mut break_writer);
                 }
                 _ => {}
             }
@@ -112,7 +129,17 @@ fn collect_actions(packet: &BedrockProtocol) -> Vec<BlockAction> {
 }
 
 /// Puts the held block against the face the player clicked.
-fn place_block(action: &BlockAction, entity: &PlayerEntity, player: &Player, level: &mut Level, registry: &BlockRegistry, block_writer: &mut MessageWriter<BlockUpdatedMessage>) {
+#[allow(clippy::too_many_arguments)]
+fn place_block(
+    player_entity: Entity,
+    action: &BlockAction,
+    entity: &PlayerEntity,
+    player: &Player,
+    level: &mut Level,
+    registry: &BlockRegistry,
+    block_writer: &mut MessageWriter<BlockUpdatedMessage>,
+    place_writer: &mut MessageWriter<BlockPlaceMessage>,
+) {
     // the block comes from the server's own inventory, never from what the client claims
     let block_id = player.inventory.held_item().block_runtime_id;
     if block_id == 0 {
@@ -138,6 +165,13 @@ fn place_block(action: &BlockAction, entity: &PlayerEntity, player: &Player, lev
     debug!("placing block {} at {}", block_id, position);
 
     level.set_block(0, position.x, position.y, position.z, 0, block_id, block_writer);
+
+    place_writer.write(BlockPlaceMessage {
+        entity: player_entity,
+        position,
+        block_id,
+        face: action.face,
+    });
 }
 
 fn attack_block(action: &BlockAction, entity: &PlayerEntity, player: &mut Player, level: &Level, registry: &BlockRegistry, event_writer: &mut MessageWriter<LevelEventMessage>) {
@@ -188,6 +222,7 @@ fn stop_break(player: &mut Player, event_writer: &mut MessageWriter<LevelEventMe
 
 #[allow(clippy::too_many_arguments)]
 fn break_block(
+    player_entity: Entity,
     action: &BlockAction,
     entity: &PlayerEntity,
     player: &mut Player,
@@ -195,6 +230,7 @@ fn break_block(
     registry: &BlockRegistry,
     event_writer: &mut MessageWriter<LevelEventMessage>,
     block_writer: &mut MessageWriter<BlockUpdatedMessage>,
+    break_writer: &mut MessageWriter<BlockBreakMessage>,
 ) {
     stop_break(player, event_writer);
 
@@ -230,6 +266,12 @@ fn break_block(
     });
 
     level.set_block(0, position.x, position.y, position.z, 0, air_id, block_writer);
+
+    break_writer.write(BlockBreakMessage {
+        entity: player_entity,
+        position,
+        block_id,
+    });
 }
 
 pub fn update_block_breaking(mut query: Query<(&PlayerEntity, &mut Player)>, mut event_writer: MessageWriter<LevelEventMessage>, mut sound_writer: MessageWriter<LevelSoundMessage>) {

--- a/src/network/handler/chat.rs
+++ b/src/network/handler/chat.rs
@@ -5,7 +5,7 @@ use crate::player::identity::PlayerIdentity;
 use bedrock::protocol::ProtoVersionPackets;
 use bedrock::protocol::v924::enums::TextPacketType;
 use bevy_ecs::message::{Message, MessageReader, MessageWriter};
-use bevy_ecs::prelude::Query;
+use bevy_ecs::prelude::{Entity, Query};
 use tracing::info;
 
 type TextPacket = <BedrockProtocol as ProtoVersionPackets>::TextPacket;
@@ -27,12 +27,13 @@ impl BroadcastMessage {
 
 #[derive(Message)]
 pub struct PlayerChatMessage {
+    pub entity: Entity,
     pub sender_name: String,
     pub sender_xuid: String,
     pub message: String,
 }
 
-pub fn handle_text(packet: &TextPacket, identity: &PlayerIdentity, chat_writer: &mut MessageWriter<PlayerChatMessage>) {
+pub fn handle_text(entity: Entity, packet: &TextPacket, identity: &PlayerIdentity, chat_writer: &mut MessageWriter<PlayerChatMessage>) {
     let TextPacketType::Chat { message, .. } = &packet.message_type else {
         return;
     };
@@ -45,6 +46,7 @@ pub fn handle_text(packet: &TextPacket, identity: &PlayerIdentity, chat_writer: 
     info!("<{}> {}", identity.name(), message);
 
     chat_writer.write(PlayerChatMessage {
+        entity,
         sender_name: identity.name().to_string(),
         sender_xuid: identity.xuid().to_string(),
         message: message.to_string(),

--- a/src/network/handler/form.rs
+++ b/src/network/handler/form.rs
@@ -1,11 +1,26 @@
 use crate::network::BedrockProtocol;
 use crate::player::Player;
 use bedrock::protocol::ProtoVersionPackets;
+use bevy_ecs::message::{Message, MessageWriter};
+use bevy_ecs::prelude::Entity;
 
-pub fn handle_modal_form_response(packet: &<BedrockProtocol as ProtoVersionPackets>::ModalFormResponsePacket, player: &mut Player) {
+#[derive(Message, Clone, Debug)]
+pub struct FormResponseMessage {
+    pub entity: Entity,
+    pub form_id: u32,
+}
+
+pub fn handle_modal_form_response(
+    entity: Entity,
+    packet: &<BedrockProtocol as ProtoVersionPackets>::ModalFormResponsePacket,
+    player: &mut Player,
+    form_writer: &mut MessageWriter<FormResponseMessage>,
+) {
     let Some((_form, on_response)) = player.forms_pending.remove(&packet.form_id) else {
         return;
     };
 
     on_response();
+
+    form_writer.write(FormResponseMessage { entity, form_id: packet.form_id });
 }

--- a/src/network/handler/inventory.rs
+++ b/src/network/handler/inventory.rs
@@ -19,11 +19,29 @@ use bedrock::protocol::v944::enums::ContainerEnumName;
 use bedrock::protocol::v944::types::NetworkBlockPosition;
 use bedrock::protocol::v975::packets::MobEquipmentPacket;
 use bedrock::protocol::v1001::packets::InventoryContentPacket;
-use bevy_ecs::message::MessageReader;
-use bevy_ecs::prelude::{Query, Res};
+use bevy_ecs::message::{Message, MessageReader, MessageWriter};
+use bevy_ecs::prelude::{Entity, Query, Res};
 use tracing::debug;
 
 const PLAYER_WINDOW: ContainerID = ContainerID::First;
+
+#[derive(Message, Clone, Debug)]
+pub struct InventoryOpenMessage {
+    pub entity: Entity,
+    pub container_id: u32,
+}
+
+#[derive(Message, Clone, Debug)]
+pub struct InventoryCloseMessage {
+    pub entity: Entity,
+    pub container_id: u32,
+}
+
+#[derive(Message, Clone, Debug)]
+pub struct PlayerItemHeldMessage {
+    pub entity: Entity,
+    pub slot: u8,
+}
 
 pub fn send_initial_inventory(mut sessions: Query<(&mut Session, &mut Player)>, mut state_reader: MessageReader<SessionStateChangedMessage>) {
     for ev in state_reader.read() {
@@ -49,6 +67,9 @@ pub fn handle_inventory_packets(
     items: Res<ItemRegistry>,
     level: Res<Level>,
     mut query: Query<(&mut Session, &mut Player)>,
+    mut open_writer: MessageWriter<InventoryOpenMessage>,
+    mut close_writer: MessageWriter<InventoryCloseMessage>,
+    mut held_writer: MessageWriter<PlayerItemHeldMessage>,
 ) {
     for ev in packet_reader.read() {
         let Ok((mut session, mut player)) = query.get_mut(ev.entity) else {
@@ -75,6 +96,11 @@ pub fn handle_inventory_packets(
                     }
                     .into(),
                 ));
+
+                open_writer.write(InventoryOpenMessage {
+                    entity: ev.entity,
+                    container_id: PLAYER_WINDOW as u32,
+                });
             }
             // the client expects an ACK for every close, otherwise it refuses to open
             // another window afterwards. interesting
@@ -87,6 +113,11 @@ pub fn handle_inventory_packets(
                     }
                     .into(),
                 ));
+
+                close_writer.write(InventoryCloseMessage {
+                    entity: ev.entity,
+                    container_id: packet.container_id.clone() as u32,
+                });
             }
             BedrockProtocol::MobEquipmentPacket(packet) => {
                 // the offhand uses the same packet, only the main inventory changes the held slot
@@ -99,6 +130,8 @@ pub fn handle_inventory_packets(
                     send_held_item(&mut session, &player);
                     continue;
                 }
+
+                held_writer.write(PlayerItemHeldMessage { entity: ev.entity, slot });
 
                 // creative picks are the only way items enter an inventory right now, and they
                 // arrive as item stack requests chorus cannot read yet

--- a/src/network/handler/login.rs
+++ b/src/network/handler/login.rs
@@ -13,8 +13,8 @@ use bedrock::network::encryption::Encryption;
 use bedrock::protocol::ProtoCodecLE;
 use bedrock::protocol::v662::enums::PlayStatus;
 use bedrock::protocol::v662::packets::ServerToClientHandshakePacket;
-use bevy_ecs::message::MessageReader;
-use bevy_ecs::prelude::{Commands, MessageWriter, Query, Res};
+use bevy_ecs::message::{Message, MessageReader};
+use bevy_ecs::prelude::{Commands, Entity, MessageWriter, Query, Res};
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use p384::elliptic_curve::Generate;
 use p384::pkcs8::DecodePublicKey;
@@ -23,11 +23,19 @@ use rand::RngExt;
 use std::io::Read;
 use tracing::*;
 
+#[derive(Message, Clone, Debug)]
+pub struct PlayerLoginMessage {
+    pub entity: Entity,
+    pub name: String,
+    pub xuid: String,
+}
+
 pub fn handle_login(
     config: Res<Config>,
     oidc: Option<Res<Auth>>,
     mut reader: MessageReader<PacketReceivedMessage>,
     mut writer: MessageWriter<SessionStateChangedMessage>,
+    mut login_writer: MessageWriter<PlayerLoginMessage>,
     mut sessions: Query<&mut Session>,
     mut commands: Commands,
 ) {
@@ -54,6 +62,12 @@ pub fn handle_login(
         }
 
         commands.entity(ev.entity).insert(PlayerIdentity::new(request.auth_data.xname.clone(), request.auth_data.xid.clone()));
+
+        login_writer.write(PlayerLoginMessage {
+            entity: ev.entity,
+            name: request.auth_data.xname.clone(),
+            xuid: request.auth_data.xid.clone(),
+        });
 
         if config.encryption {
             let mut token = [0u8; 16];

--- a/src/network/handler/play.rs
+++ b/src/network/handler/play.rs
@@ -4,7 +4,7 @@ use crate::level::BlockUpdatedMessage;
 use crate::network::BedrockProtocol;
 use crate::network::handler::PacketReceivedMessage;
 use crate::network::handler::chat::{BroadcastMessage, PlayerChatMessage, handle_text};
-use crate::network::handler::form::handle_modal_form_response;
+use crate::network::handler::form::{FormResponseMessage, handle_modal_form_response};
 use crate::network::session::Session;
 use crate::network::session::state::{SessionState, SessionStateChangedMessage};
 use crate::player::Player;
@@ -175,6 +175,7 @@ pub fn handle_play(
     mut command_preprocess_writer: MessageWriter<CommandPreprocessMessage>,
     mut command_writer: MessageWriter<CommandRequestedMessage>,
     mut move_writer: MessageWriter<PlayerMoveMessage>,
+    mut form_writer: MessageWriter<FormResponseMessage>,
     mut query: Query<(&mut PlayerEntity, &mut Player, &mut Session, &PlayerIdentity)>,
 ) {
     for ev in packet_reader.read() {
@@ -218,7 +219,7 @@ pub fn handle_play(
                     line: packet.command.clone(),
                 });
             }
-            BedrockProtocol::ModalFormResponsePacket(packet) => handle_modal_form_response(packet, &mut player),
+            BedrockProtocol::ModalFormResponsePacket(packet) => handle_modal_form_response(ev.entity, packet, &mut player, &mut form_writer),
             packet => {
                 let count = session.unhandled_packets.entry(packet.as_ref().meta().name).or_insert(0);
                 *count = count.saturating_add(1);

--- a/src/network/handler/play.rs
+++ b/src/network/handler/play.rs
@@ -1,4 +1,4 @@
-use crate::command::dispatch::CommandRequestedMessage;
+use crate::command::dispatch::{CommandPreprocessMessage, CommandRequestedMessage};
 use crate::entity::entity::Entity as PlayerEntity;
 use crate::level::BlockUpdatedMessage;
 use crate::network::BedrockProtocol;
@@ -163,6 +163,7 @@ pub fn announce_join_quit(mut join_reader: MessageReader<PlayerJoinedMessage>, m
 pub fn handle_play(
     mut packet_reader: MessageReader<PacketReceivedMessage>,
     mut chat_writer: MessageWriter<PlayerChatMessage>,
+    mut command_preprocess_writer: MessageWriter<CommandPreprocessMessage>,
     mut command_writer: MessageWriter<CommandRequestedMessage>,
     mut query: Query<(&mut PlayerEntity, &mut Player, &mut Session, &PlayerIdentity)>,
 ) {
@@ -182,8 +183,13 @@ pub fn handle_play(
                 let (pitch, yaw) = packet.player_rotation;
                 entity.rotation = Vec2::new(pitch, yaw);
             }
-            BedrockProtocol::TextPacket(packet) => handle_text(packet, identity, &mut chat_writer),
+            BedrockProtocol::TextPacket(packet) => handle_text(ev.entity, packet, identity, &mut chat_writer),
             BedrockProtocol::CommandRequestPacket(packet) => {
+                command_preprocess_writer.write(CommandPreprocessMessage {
+                    entity: ev.entity,
+                    line: packet.command.clone(),
+                });
+
                 command_writer.write(CommandRequestedMessage {
                     entity: ev.entity,
                     line: packet.command.clone(),

--- a/src/network/handler/play.rs
+++ b/src/network/handler/play.rs
@@ -160,11 +160,21 @@ pub fn announce_join_quit(mut join_reader: MessageReader<PlayerJoinedMessage>, m
     }
 }
 
+#[derive(Message, Clone, Debug)]
+pub struct PlayerMoveMessage {
+    pub entity: Entity,
+    pub from_position: Vec3,
+    pub to_position: Vec3,
+    pub from_rotation: Vec2,
+    pub to_rotation: Vec2,
+}
+
 pub fn handle_play(
     mut packet_reader: MessageReader<PacketReceivedMessage>,
     mut chat_writer: MessageWriter<PlayerChatMessage>,
     mut command_preprocess_writer: MessageWriter<CommandPreprocessMessage>,
     mut command_writer: MessageWriter<CommandRequestedMessage>,
+    mut move_writer: MessageWriter<PlayerMoveMessage>,
     mut query: Query<(&mut PlayerEntity, &mut Player, &mut Session, &PlayerIdentity)>,
 ) {
     for ev in packet_reader.read() {
@@ -179,9 +189,22 @@ pub fn handle_play(
         match &ev.packet {
             BedrockProtocol::PlayerAuthInputPacket(packet) => {
                 let (x, y, z) = packet.player_position;
-                entity.position = Vec3::new(x, y, z);
+                let new_position = Vec3::new(x, y, z);
                 let (pitch, yaw) = packet.player_rotation;
-                entity.rotation = Vec2::new(pitch, yaw);
+                let new_rotation = Vec2::new(pitch, yaw);
+
+                if new_position != entity.position || new_rotation != entity.rotation {
+                    move_writer.write(PlayerMoveMessage {
+                        entity: ev.entity,
+                        from_position: entity.position,
+                        to_position: new_position,
+                        from_rotation: entity.rotation,
+                        to_rotation: new_rotation,
+                    });
+                }
+
+                entity.position = new_position;
+                entity.rotation = new_rotation;
             }
             BedrockProtocol::TextPacket(packet) => handle_text(ev.entity, packet, identity, &mut chat_writer),
             BedrockProtocol::CommandRequestPacket(packet) => {

--- a/src/network/handler/request.rs
+++ b/src/network/handler/request.rs
@@ -6,12 +6,22 @@ use bedrock::network::compression::Compression;
 use bedrock::protocol::ProtoVersion;
 use bedrock::protocol::v662::enums::{PacketCompressionAlgorithm, PlayStatus};
 use bedrock::protocol::v662::packets::NetworkSettingsPacket;
-use bevy_ecs::message::MessageReader;
-use bevy_ecs::prelude::MessageWriter;
+use bevy_ecs::message::{Message, MessageReader};
+use bevy_ecs::prelude::{Entity, MessageWriter};
 use bevy_ecs::system::Query;
 use tracing::error;
 
-pub fn handle_request(mut reader: MessageReader<PacketReceivedMessage>, mut writer: MessageWriter<SessionStateChangedMessage>, mut sessions: Query<&mut Session>) {
+#[derive(Message, Clone, Debug)]
+pub struct PlayerPreLoginMessage {
+    pub entity: Entity,
+}
+
+pub fn handle_request(
+    mut reader: MessageReader<PacketReceivedMessage>,
+    mut writer: MessageWriter<SessionStateChangedMessage>,
+    mut pre_login_writer: MessageWriter<PlayerPreLoginMessage>,
+    mut sessions: Query<&mut Session>,
+) {
     for ev in reader.read() {
         if let Ok(mut session) = sessions.get_mut(ev.entity) {
             if session.get_state() != SessionState::Request {
@@ -39,7 +49,11 @@ pub fn handle_request(mut reader: MessageReader<PacketReceivedMessage>, mut writ
                 } else {
                     Some("disconnectionScreen.outdatedServer")
                 });
+
+                continue;
             }
+
+            pre_login_writer.write(PlayerPreLoginMessage { entity: ev.entity });
 
             let compression_threshold: u16 = 1;
 

--- a/src/network/handler/resource.rs
+++ b/src/network/handler/resource.rs
@@ -9,15 +9,30 @@ use bedrock::protocol::v662::packets::ResourcePackChunkDataPacket;
 use bedrock::protocol::v662::types::{BaseGameVersion, Experiments};
 use bedrock::protocol::v898::packets::{PackEntry, ResourcePackStackPacket};
 use bedrock::protocol::v2168::packets::{ResourcePackClientResponsePacket, ResourcePackEntry, ResourcePacksInfoPacket};
-use bevy_ecs::message::MessageReader;
-use bevy_ecs::prelude::{MessageWriter, ParamSet, Query, Res};
+use bevy_ecs::message::{Message, MessageReader};
+use bevy_ecs::prelude::{Entity, MessageWriter, ParamSet, Query, Res};
 use tracing::warn;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResourcePackResponseKind {
+    Cancelled,
+    Downloading,
+    DownloadingFinished,
+    StackFinished,
+}
+
+#[derive(Message, Clone, Debug)]
+pub struct ResourcePackResponseMessage {
+    pub entity: Entity,
+    pub response: ResourcePackResponseKind,
+}
 
 pub fn handle_resource(
     config: Res<Config>,
     resource_packs: Res<ResourcePacks>,
     mut packet_reader: MessageReader<PacketReceivedMessage>,
     mut state_message_set: ParamSet<(MessageReader<SessionStateChangedMessage>, MessageWriter<SessionStateChangedMessage>)>,
+    mut response_writer: MessageWriter<ResourcePackResponseMessage>,
     mut sessions: Query<&mut Session>,
 ) {
     for ev in state_message_set.p0().read() {
@@ -70,7 +85,7 @@ pub fn handle_resource(
                 handle_chunk_request(&mut session, &resource_packs, &packet.resource_name, packet.chunk);
             }
             BedrockProtocol::ResourcePackClientResponsePacket(packet) => {
-                handle_client_response(&config, &mut session, &resource_packs, packet, &mut state_message_set.p1());
+                handle_client_response(ev.entity, &config, &mut session, &resource_packs, packet, &mut state_message_set.p1(), &mut response_writer);
             }
             _ => continue,
         }
@@ -102,21 +117,38 @@ fn handle_chunk_request(session: &mut Session, resource_packs: &ResourcePacks, r
     ));
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_client_response(
+    entity: Entity,
     config: &Config,
     session: &mut Session,
     resource_packs: &ResourcePacks,
     packet: &<BedrockProtocol as ProtoVersionPackets>::ResourcePackClientResponsePacket,
     state_writer: &mut MessageWriter<SessionStateChangedMessage>,
+    response_writer: &mut MessageWriter<ResourcePackResponseMessage>,
 ) {
     match packet {
         ResourcePackClientResponsePacket::Cancel => {
+            response_writer.write(ResourcePackResponseMessage {
+                entity,
+                response: ResourcePackResponseKind::Cancelled,
+            });
+
             session.close(Some("disconnectionScreen.noReason"));
         }
         ResourcePackClientResponsePacket::Downloading(_) => {
             // Client has begun downloading; chunk requests will follow.
+            response_writer.write(ResourcePackResponseMessage {
+                entity,
+                response: ResourcePackResponseKind::Downloading,
+            });
         }
         ResourcePackClientResponsePacket::DownloadingFinished => {
+            response_writer.write(ResourcePackResponseMessage {
+                entity,
+                response: ResourcePackResponseKind::DownloadingFinished,
+            });
+
             let addon_list: Vec<PackEntry> = resource_packs
                 .packs()
                 .iter()
@@ -142,6 +174,11 @@ fn handle_client_response(
             ));
         }
         ResourcePackClientResponsePacket::ResourcePackStackFinished => {
+            response_writer.write(ResourcePackResponseMessage {
+                entity,
+                response: ResourcePackResponseKind::StackFinished,
+            });
+
             session.set_state(SessionState::Setup, state_writer);
         }
     }

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -3,6 +3,7 @@ use crate::config::Config;
 use crate::level::{BlockUpdatedMessage, LevelEventMessage, LevelSoundMessage};
 use crate::network::BedrockProtocol;
 use crate::network::bandwidth::BandwidthTracker;
+use crate::network::handler::block::{BlockBreakMessage, BlockPlaceMessage};
 use crate::network::handler::chat::{BroadcastMessage, PlayerChatMessage};
 use crate::network::handler::play::{PlayerJoinedMessage, PlayerQuitMessage};
 use crate::network::handler::{PacketHandlers, PacketReceivedMessage};
@@ -43,6 +44,8 @@ impl Plugin for Network {
             .add_message::<PlayerJoinedMessage>()
             .add_message::<PlayerQuitMessage>()
             .add_message::<BlockUpdatedMessage>()
+            .add_message::<BlockBreakMessage>()
+            .add_message::<BlockPlaceMessage>()
             .add_message::<PlayerChatMessage>()
             .add_message::<CommandRequestedMessage>()
             .add_message::<BroadcastMessage>()

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -5,6 +5,7 @@ use crate::network::BedrockProtocol;
 use crate::network::bandwidth::BandwidthTracker;
 use crate::network::handler::block::{BlockBreakMessage, BlockPlaceMessage};
 use crate::network::handler::chat::{BroadcastMessage, PlayerChatMessage};
+use crate::network::handler::form::FormResponseMessage;
 use crate::network::handler::inventory::{InventoryCloseMessage, InventoryOpenMessage, PlayerItemHeldMessage};
 use crate::network::handler::login::PlayerLoginMessage;
 use crate::network::handler::play::{PlayerJoinedMessage, PlayerMoveMessage, PlayerQuitMessage};
@@ -57,6 +58,7 @@ impl Plugin for Network {
             .add_message::<InventoryOpenMessage>()
             .add_message::<InventoryCloseMessage>()
             .add_message::<PlayerItemHeldMessage>()
+            .add_message::<FormResponseMessage>()
             .add_message::<PlayerChatMessage>()
             .add_message::<CommandPreprocessMessage>()
             .add_message::<CommandRequestedMessage>()

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -1,4 +1,4 @@
-use crate::command::dispatch::CommandRequestedMessage;
+use crate::command::dispatch::{CommandPreprocessMessage, CommandRequestedMessage};
 use crate::config::Config;
 use crate::level::{BlockUpdatedMessage, LevelEventMessage, LevelSoundMessage};
 use crate::network::BedrockProtocol;
@@ -51,6 +51,7 @@ impl Plugin for Network {
             .add_message::<InventoryCloseMessage>()
             .add_message::<PlayerItemHeldMessage>()
             .add_message::<PlayerChatMessage>()
+            .add_message::<CommandPreprocessMessage>()
             .add_message::<CommandRequestedMessage>()
             .add_message::<BroadcastMessage>()
             .add_message::<LevelEventMessage>()

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -5,6 +5,7 @@ use crate::network::BedrockProtocol;
 use crate::network::bandwidth::BandwidthTracker;
 use crate::network::handler::block::{BlockBreakMessage, BlockPlaceMessage};
 use crate::network::handler::chat::{BroadcastMessage, PlayerChatMessage};
+use crate::network::handler::inventory::{InventoryCloseMessage, InventoryOpenMessage, PlayerItemHeldMessage};
 use crate::network::handler::play::{PlayerJoinedMessage, PlayerQuitMessage};
 use crate::network::handler::{PacketHandlers, PacketReceivedMessage};
 use crate::network::login::auth::LoginAuthOIDC;
@@ -46,6 +47,9 @@ impl Plugin for Network {
             .add_message::<BlockUpdatedMessage>()
             .add_message::<BlockBreakMessage>()
             .add_message::<BlockPlaceMessage>()
+            .add_message::<InventoryOpenMessage>()
+            .add_message::<InventoryCloseMessage>()
+            .add_message::<PlayerItemHeldMessage>()
             .add_message::<PlayerChatMessage>()
             .add_message::<CommandRequestedMessage>()
             .add_message::<BroadcastMessage>()

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -8,6 +8,7 @@ use crate::network::handler::chat::{BroadcastMessage, PlayerChatMessage};
 use crate::network::handler::inventory::{InventoryCloseMessage, InventoryOpenMessage, PlayerItemHeldMessage};
 use crate::network::handler::login::PlayerLoginMessage;
 use crate::network::handler::play::{PlayerJoinedMessage, PlayerMoveMessage, PlayerQuitMessage};
+use crate::network::handler::request::PlayerPreLoginMessage;
 use crate::network::handler::resource::ResourcePackResponseMessage;
 use crate::network::handler::{PacketHandlers, PacketReceivedMessage};
 use crate::network::login::auth::LoginAuthOIDC;
@@ -47,6 +48,7 @@ impl Plugin for Network {
             .add_message::<PlayerJoinedMessage>()
             .add_message::<PlayerQuitMessage>()
             .add_message::<PlayerLoginMessage>()
+            .add_message::<PlayerPreLoginMessage>()
             .add_message::<PlayerMoveMessage>()
             .add_message::<ResourcePackResponseMessage>()
             .add_message::<BlockUpdatedMessage>()

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -7,6 +7,7 @@ use crate::network::handler::block::{BlockBreakMessage, BlockPlaceMessage};
 use crate::network::handler::chat::{BroadcastMessage, PlayerChatMessage};
 use crate::network::handler::inventory::{InventoryCloseMessage, InventoryOpenMessage, PlayerItemHeldMessage};
 use crate::network::handler::play::{PlayerJoinedMessage, PlayerMoveMessage, PlayerQuitMessage};
+use crate::network::handler::resource::ResourcePackResponseMessage;
 use crate::network::handler::{PacketHandlers, PacketReceivedMessage};
 use crate::network::login::auth::LoginAuthOIDC;
 use crate::network::session::Session;
@@ -45,6 +46,7 @@ impl Plugin for Network {
             .add_message::<PlayerJoinedMessage>()
             .add_message::<PlayerQuitMessage>()
             .add_message::<PlayerMoveMessage>()
+            .add_message::<ResourcePackResponseMessage>()
             .add_message::<BlockUpdatedMessage>()
             .add_message::<BlockBreakMessage>()
             .add_message::<BlockPlaceMessage>()

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -6,6 +6,7 @@ use crate::network::bandwidth::BandwidthTracker;
 use crate::network::handler::block::{BlockBreakMessage, BlockPlaceMessage};
 use crate::network::handler::chat::{BroadcastMessage, PlayerChatMessage};
 use crate::network::handler::inventory::{InventoryCloseMessage, InventoryOpenMessage, PlayerItemHeldMessage};
+use crate::network::handler::login::PlayerLoginMessage;
 use crate::network::handler::play::{PlayerJoinedMessage, PlayerMoveMessage, PlayerQuitMessage};
 use crate::network::handler::resource::ResourcePackResponseMessage;
 use crate::network::handler::{PacketHandlers, PacketReceivedMessage};
@@ -45,6 +46,7 @@ impl Plugin for Network {
             .add_message::<SessionStateChangedMessage>()
             .add_message::<PlayerJoinedMessage>()
             .add_message::<PlayerQuitMessage>()
+            .add_message::<PlayerLoginMessage>()
             .add_message::<PlayerMoveMessage>()
             .add_message::<ResourcePackResponseMessage>()
             .add_message::<BlockUpdatedMessage>()

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -6,7 +6,7 @@ use crate::network::bandwidth::BandwidthTracker;
 use crate::network::handler::block::{BlockBreakMessage, BlockPlaceMessage};
 use crate::network::handler::chat::{BroadcastMessage, PlayerChatMessage};
 use crate::network::handler::inventory::{InventoryCloseMessage, InventoryOpenMessage, PlayerItemHeldMessage};
-use crate::network::handler::play::{PlayerJoinedMessage, PlayerQuitMessage};
+use crate::network::handler::play::{PlayerJoinedMessage, PlayerMoveMessage, PlayerQuitMessage};
 use crate::network::handler::{PacketHandlers, PacketReceivedMessage};
 use crate::network::login::auth::LoginAuthOIDC;
 use crate::network::session::Session;
@@ -44,6 +44,7 @@ impl Plugin for Network {
             .add_message::<SessionStateChangedMessage>()
             .add_message::<PlayerJoinedMessage>()
             .add_message::<PlayerQuitMessage>()
+            .add_message::<PlayerMoveMessage>()
             .add_message::<BlockUpdatedMessage>()
             .add_message::<BlockBreakMessage>()
             .add_message::<BlockPlaceMessage>()


### PR DESCRIPTION
## Summary

Continues the incremental rollout of the Message/MessageWriter/MessageReader
event system started with PlayerJoinedMessage/PlayerQuitMessage. This PR adds:

**Block**
- `BlockBreakMessage` - emitted after a block is successfully broken
- `BlockPlaceMessage` - emitted after a block is successfully placed

**Inventory**
- `InventoryOpenMessage` / `InventoryCloseMessage` - container window open/close
- `PlayerItemHeldMessage` - held hotbar slot changes

**Chat / Command**
- `PlayerChatMessage` now carries the sender's `entity` (previously only
  name/xuid/text), so consumers can look up player components
- `CommandPreprocessMessage` - fired before a command line is dispatched,
  mirroring PocketMine's `PlayerCommandPreprocessEvent`

**Movement**
- `PlayerMoveMessage` - fired only when position/rotation actually changes
  (guarded against the idle-tick spam of `PlayerAuthInputPacket`)

**Login / Resource pack**
- `PlayerPreLoginMessage` - fired once a connection's protocol version is
  accepted, before any identity is known
- `PlayerLoginMessage` - fired once auth data is validated and `PlayerIdentity`
  is attached
- `ResourcePackResponseMessage` - fired for each stage of the client's
  resource pack response (Cancelled, Downloading, DownloadingFinished,
  StackFinished)

**Form**
- `FormResponseMessage` - fired after a pending form's `on_response`
  callback runs

**Bugfix (unrelated to events, found while adding `PlayerPreLoginMessage`)**
- `handle_request` was missing a `continue` after `session.close()` on a
  protocol version mismatch, so it kept sending packets and advancing the
  session state on an already-closed session.

All new events are post-events (fired after the action already happened)
and are not cancellable yet - they are hook points for future consumers
(logging, plugins, protection systems, permissions, etc.), following the
same co-location convention used throughout: event struct next to the
system that produces it, registered centrally in `network.rs`.

## Related issues

<!-- Fixes/Closes: #<issue-number> if there's an open issue for this -->

## Type of change

- Feature
- Bugfix (the `handle_request` early-return fix)

## Checklist

- [x] My code follows the project style (ran `cargo fmt`)
- [x] I ran `cargo clippy` and addressed warnings where appropriate
- [ ] I added tests for new behavior (not applicable - no test suite in this repo yet)
- [x] All CI checks pass
- [ ] I updated relevant documentation (not applicable)

## Test Plan

Ran the server locally and verified all touched flows (breaking/placing
blocks, opening/closing inventory, switching held slot, chatting, running
commands, moving, accepting resource packs, logging in, submitting forms)
behave exactly as before - this PR only exposes existing logic as events,
it does not change observable behavior except for the `handle_request`
bugfix. Confirmed via `cargo check`/`cargo fmt --check` that everything
compiles and is formatted correctly.

## Notes for reviewers

Happy to split this into smaller PRs by area (block/inventory, chat/command,
movement, login/resource pack, form) if that's easier to review - let me
know your preference for future batches.