### PR TITLE
feat(events): add session lifecycle, movement toggle, and item interaction events

### DIFF
--- a/src/network/handler/block.rs
+++ b/src/network/handler/block.rs
@@ -1,5 +1,6 @@
 use crate::block::component::mineable_component::MineableComponent;
 use crate::entity::entity::Entity as PlayerEntity;
+use crate::item::item_stack::ItemStack;
 use crate::level::level::Level;
 use crate::level::{BlockUpdatedMessage, LevelEventMessage, LevelSoundMessage};
 use crate::math::enums::block_face::BlockFace;
@@ -50,6 +51,12 @@ pub struct BlockPlaceMessage {
     pub face: i32,
 }
 
+#[derive(Message, Clone, Debug)]
+pub struct PlayerDropItemMessage {
+    pub entity: Entity,
+    pub item: ItemStack,
+}
+
 pub fn handle_block_actions(
     mut packet_reader: MessageReader<PacketReceivedMessage>,
     mut query: Query<(&Session, &PlayerEntity, &mut Player)>,
@@ -59,6 +66,7 @@ pub fn handle_block_actions(
     mut block_writer: MessageWriter<BlockUpdatedMessage>,
     mut break_writer: MessageWriter<BlockBreakMessage>,
     mut place_writer: MessageWriter<BlockPlaceMessage>,
+    mut drop_writer: MessageWriter<PlayerDropItemMessage>,
 ) {
     for ev in packet_reader.read() {
         let Ok((session, entity, mut player)) = query.get_mut(ev.entity) else {
@@ -95,6 +103,12 @@ pub fn handle_block_actions(
                 }
                 PlayerActionType::PredictDestroyBlock | PlayerActionType::CreativeDestroyBlock => {
                     break_block(ev.entity, &action, entity, &mut player, &mut level, &registry, &mut event_writer, &mut block_writer, &mut break_writer);
+                }
+                PlayerActionType::DropItem => {
+                    drop_writer.write(PlayerDropItemMessage {
+                        entity: ev.entity,
+                        item: *player.inventory.held_item(),
+                    });
                 }
                 _ => {}
             }

--- a/src/network/handler/block.rs
+++ b/src/network/handler/block.rs
@@ -57,6 +57,13 @@ pub struct PlayerDropItemMessage {
     pub item: ItemStack,
 }
 
+#[derive(Message, Clone, Debug)]
+pub struct BlockInteractMessage {
+    pub entity: Entity,
+    pub position: IVec3,
+    pub face: i32,
+}
+
 pub fn handle_block_actions(
     mut packet_reader: MessageReader<PacketReceivedMessage>,
     mut query: Query<(&Session, &PlayerEntity, &mut Player)>,
@@ -67,6 +74,7 @@ pub fn handle_block_actions(
     mut break_writer: MessageWriter<BlockBreakMessage>,
     mut place_writer: MessageWriter<BlockPlaceMessage>,
     mut drop_writer: MessageWriter<PlayerDropItemMessage>,
+    mut interact_writer: MessageWriter<BlockInteractMessage>,
 ) {
     for ev in packet_reader.read() {
         let Ok((session, entity, mut player)) = query.get_mut(ev.entity) else {
@@ -108,6 +116,13 @@ pub fn handle_block_actions(
                     drop_writer.write(PlayerDropItemMessage {
                         entity: ev.entity,
                         item: *player.inventory.held_item(),
+                    });
+                }
+                PlayerActionType::InteractWithBlock => {
+                    interact_writer.write(BlockInteractMessage {
+                        entity: ev.entity,
+                        position: action.position,
+                        face: action.face,
                     });
                 }
                 _ => {}

--- a/src/network/handler/chunks.rs
+++ b/src/network/handler/chunks.rs
@@ -11,7 +11,7 @@ use bedrock::protocol::v662::types::{BlockPos, ChunkPos};
 use bedrock::protocol::v2168::packets::{HeightMapDataType, LevelChunkPacket, SubChunkDataEntry, SubChunkPacket, SubChunkRequestResult};
 use bedrock::protocol::v2168::types::SubChunkPos;
 use bevy_ecs::change_detection::ResMut;
-use bevy_ecs::message::MessageReader;
+use bevy_ecs::message::{Message, MessageReader, MessageWriter};
 use bevy_ecs::prelude::{Entity, Query};
 use bevy_ecs::system::Res;
 use bevy_tasks::ComputeTaskPool;
@@ -24,6 +24,13 @@ struct ChunkPayload {
     sub_chunk_count: u32,
     sub_chunk_limit: u16,
     data: Vec<u8>,
+}
+
+#[derive(Message, Clone, Debug)]
+pub struct ChunkSentMessage {
+    pub entity: Entity,
+    pub x: i32,
+    pub z: i32,
 }
 
 pub fn update_chunk_order(mut query: Query<(&mut Session, &PlayerEntity, &mut Player)>) {
@@ -67,7 +74,7 @@ pub fn update_chunk_order(mut query: Query<(&mut Session, &PlayerEntity, &mut Pl
     }
 }
 
-pub fn send_pending_chunks(mut query: Query<(Entity, &mut Session, &PlayerEntity, &mut Player)>, mut level: ResMut<Level>, registry: Res<BlockRegistry>) {
+pub fn send_pending_chunks(mut query: Query<(Entity, &mut Session, &PlayerEntity, &mut Player)>, mut level: ResMut<Level>, registry: Res<BlockRegistry>, mut chunk_sent_writer: MessageWriter<ChunkSentMessage>) {
     let mut batches: HashMap<Entity, Vec<(i32, i32)>> = HashMap::new();
 
     for (entity, _, _, mut player) in query.iter_mut() {
@@ -118,6 +125,8 @@ pub fn send_pending_chunks(mut query: Query<(Entity, &mut Session, &PlayerEntity
                 }
                 .into(),
             ));
+
+            chunk_sent_writer.write(ChunkSentMessage { entity, x, z });
 
             debug!("sent chunk {}, {}", x, z);
         }

--- a/src/network/handler/chunks.rs
+++ b/src/network/handler/chunks.rs
@@ -74,7 +74,12 @@ pub fn update_chunk_order(mut query: Query<(&mut Session, &PlayerEntity, &mut Pl
     }
 }
 
-pub fn send_pending_chunks(mut query: Query<(Entity, &mut Session, &PlayerEntity, &mut Player)>, mut level: ResMut<Level>, registry: Res<BlockRegistry>, mut chunk_sent_writer: MessageWriter<ChunkSentMessage>) {
+pub fn send_pending_chunks(
+    mut query: Query<(Entity, &mut Session, &PlayerEntity, &mut Player)>,
+    mut level: ResMut<Level>,
+    registry: Res<BlockRegistry>,
+    mut chunk_sent_writer: MessageWriter<ChunkSentMessage>,
+) {
     let mut batches: HashMap<Entity, Vec<(i32, i32)>> = HashMap::new();
 
     for (entity, _, _, mut player) in query.iter_mut() {

--- a/src/network/handler/play.rs
+++ b/src/network/handler/play.rs
@@ -17,7 +17,7 @@ use bedrock::protocol::v729::packets::{AttributeData, UpdateAttributesPacket};
 use bedrock::protocol::v776::enums::AbilitiesIndex;
 use bedrock::protocol::v776::types::{SerializedAbilitiesData, SerializedAbilitiesLayer, SerializedLayer};
 use bedrock::protocol::v944::types::NetworkBlockPosition;
-use bedrock::protocol::v2168::enums::DataItemType;
+use bedrock::protocol::v2168::enums::{DataItemType, PlayerAuthInputData};
 use bevy_ecs::message::{Message, MessageReader, MessageWriter};
 use bevy_ecs::prelude::{Entity, Query, Res};
 use glam::{Vec2, Vec3};
@@ -169,12 +169,33 @@ pub struct PlayerMoveMessage {
     pub to_rotation: Vec2,
 }
 
+#[derive(Message, Clone, Debug)]
+pub struct PlayerToggleSneakMessage {
+    pub entity: Entity,
+    pub sneaking: bool,
+}
+
+#[derive(Message, Clone, Debug)]
+pub struct PlayerToggleSprintMessage {
+    pub entity: Entity,
+    pub sprinting: bool,
+}
+
+#[derive(Message, Clone, Debug)]
+pub struct PlayerToggleFlightMessage {
+    pub entity: Entity,
+    pub flying: bool,
+}
+
 pub fn handle_play(
     mut packet_reader: MessageReader<PacketReceivedMessage>,
     mut chat_writer: MessageWriter<PlayerChatMessage>,
     mut command_preprocess_writer: MessageWriter<CommandPreprocessMessage>,
     mut command_writer: MessageWriter<CommandRequestedMessage>,
     mut move_writer: MessageWriter<PlayerMoveMessage>,
+    mut sneak_writer: MessageWriter<PlayerToggleSneakMessage>,
+    mut sprint_writer: MessageWriter<PlayerToggleSprintMessage>,
+    mut flight_writer: MessageWriter<PlayerToggleFlightMessage>,
     mut form_writer: MessageWriter<FormResponseMessage>,
     mut query: Query<(&mut PlayerEntity, &mut Player, &mut Session, &PlayerIdentity)>,
 ) {
@@ -206,6 +227,24 @@ pub fn handle_play(
 
                 entity.position = new_position;
                 entity.rotation = new_rotation;
+
+                if packet.input_data.contains(&PlayerAuthInputData::StartSneaking) {
+                    sneak_writer.write(PlayerToggleSneakMessage { entity: ev.entity, sneaking: true });
+                } else if packet.input_data.contains(&PlayerAuthInputData::StopSneaking) {
+                    sneak_writer.write(PlayerToggleSneakMessage { entity: ev.entity, sneaking: false });
+                }
+
+                if packet.input_data.contains(&PlayerAuthInputData::StartSprinting) {
+                    sprint_writer.write(PlayerToggleSprintMessage { entity: ev.entity, sprinting: true });
+                } else if packet.input_data.contains(&PlayerAuthInputData::StopSprinting) {
+                    sprint_writer.write(PlayerToggleSprintMessage { entity: ev.entity, sprinting: false });
+                }
+
+                if packet.input_data.contains(&PlayerAuthInputData::StartFlying) {
+                    flight_writer.write(PlayerToggleFlightMessage { entity: ev.entity, flying: true });
+                } else if packet.input_data.contains(&PlayerAuthInputData::StopFlying) {
+                    flight_writer.write(PlayerToggleFlightMessage { entity: ev.entity, flying: false });
+                }
             }
             BedrockProtocol::TextPacket(packet) => handle_text(ev.entity, packet, identity, &mut chat_writer),
             BedrockProtocol::CommandRequestPacket(packet) => {

--- a/src/network/handler/play.rs
+++ b/src/network/handler/play.rs
@@ -1,5 +1,6 @@
 use crate::command::dispatch::{CommandPreprocessMessage, CommandRequestedMessage};
 use crate::entity::entity::Entity as PlayerEntity;
+use crate::item::item_stack::ItemStack;
 use crate::level::BlockUpdatedMessage;
 use crate::network::BedrockProtocol;
 use crate::network::handler::PacketReceivedMessage;
@@ -192,6 +193,12 @@ pub struct PlayerJumpMessage {
     pub entity: Entity,
 }
 
+#[derive(Message, Clone, Debug)]
+pub struct PlayerItemUseMessage {
+    pub entity: Entity,
+    pub item: ItemStack,
+}
+
 pub fn handle_play(
     mut packet_reader: MessageReader<PacketReceivedMessage>,
     mut chat_writer: MessageWriter<PlayerChatMessage>,
@@ -202,6 +209,7 @@ pub fn handle_play(
     mut sprint_writer: MessageWriter<PlayerToggleSprintMessage>,
     mut flight_writer: MessageWriter<PlayerToggleFlightMessage>,
     mut jump_writer: MessageWriter<PlayerJumpMessage>,
+    mut item_use_writer: MessageWriter<PlayerItemUseMessage>,
     mut form_writer: MessageWriter<FormResponseMessage>,
     mut query: Query<(&mut PlayerEntity, &mut Player, &mut Session, &PlayerIdentity)>,
 ) {
@@ -254,6 +262,13 @@ pub fn handle_play(
 
                 if packet.input_data.contains(&PlayerAuthInputData::StartJumping) {
                     jump_writer.write(PlayerJumpMessage { entity: ev.entity });
+                }
+
+                if packet.input_data.contains(&PlayerAuthInputData::StartUsingItem) {
+                    item_use_writer.write(PlayerItemUseMessage {
+                        entity: ev.entity,
+                        item: *player.inventory.held_item(),
+                    });
                 }
             }
             BedrockProtocol::TextPacket(packet) => handle_text(ev.entity, packet, identity, &mut chat_writer),

--- a/src/network/handler/play.rs
+++ b/src/network/handler/play.rs
@@ -187,6 +187,11 @@ pub struct PlayerToggleFlightMessage {
     pub flying: bool,
 }
 
+#[derive(Message, Clone, Debug)]
+pub struct PlayerJumpMessage {
+    pub entity: Entity,
+}
+
 pub fn handle_play(
     mut packet_reader: MessageReader<PacketReceivedMessage>,
     mut chat_writer: MessageWriter<PlayerChatMessage>,
@@ -196,6 +201,7 @@ pub fn handle_play(
     mut sneak_writer: MessageWriter<PlayerToggleSneakMessage>,
     mut sprint_writer: MessageWriter<PlayerToggleSprintMessage>,
     mut flight_writer: MessageWriter<PlayerToggleFlightMessage>,
+    mut jump_writer: MessageWriter<PlayerJumpMessage>,
     mut form_writer: MessageWriter<FormResponseMessage>,
     mut query: Query<(&mut PlayerEntity, &mut Player, &mut Session, &PlayerIdentity)>,
 ) {
@@ -244,6 +250,10 @@ pub fn handle_play(
                     flight_writer.write(PlayerToggleFlightMessage { entity: ev.entity, flying: true });
                 } else if packet.input_data.contains(&PlayerAuthInputData::StopFlying) {
                     flight_writer.write(PlayerToggleFlightMessage { entity: ev.entity, flying: false });
+                }
+
+                if packet.input_data.contains(&PlayerAuthInputData::StartJumping) {
+                    jump_writer.write(PlayerJumpMessage { entity: ev.entity });
                 }
             }
             BedrockProtocol::TextPacket(packet) => handle_text(ev.entity, packet, identity, &mut chat_writer),

--- a/src/network/handler/setup.rs
+++ b/src/network/handler/setup.rs
@@ -18,8 +18,8 @@ use bedrock::protocol::v2168::enums::EducationEditionOffer;
 use bedrock::protocol::v2168::packets::StartGamePacket;
 use bedrock::protocol::v2168::types::{GameRuleLegacyData, LevelSettings};
 use bedrock::protocol::{ProtoVersion, ProtoVersionPackets};
-use bevy_ecs::message::{MessageReader, MessageWriter};
-use bevy_ecs::prelude::{Commands, Query};
+use bevy_ecs::message::{Message, MessageReader, MessageWriter};
+use bevy_ecs::prelude::{Commands, Entity, Query};
 use bevy_ecs::system::{Res, ResMut};
 use tracing::{debug, warn};
 
@@ -159,10 +159,17 @@ fn send_start_game(player: &Player, session: &mut Session) {
     ))
 }
 
+#[derive(Message, Clone, Debug)]
+pub struct PlayerChunkRadiusMessage {
+    pub entity: Entity,
+    pub radius: i32,
+}
+
 pub fn handle_setup(
     mut packet_reader: MessageReader<PacketReceivedMessage>,
     items: Res<ItemRegistry>,
     mut state_writer: MessageWriter<SessionStateChangedMessage>,
+    mut chunk_radius_writer: MessageWriter<PlayerChunkRadiusMessage>,
     mut query: Query<(&mut Player, &mut Session)>,
 ) {
     for ev in packet_reader.read() {
@@ -173,7 +180,7 @@ pub fn handle_setup(
             continue;
         }
         match &ev.packet {
-            BedrockProtocol::RequestChunkRadiusPacket(packet) => handle_request_chunk_radius(packet, &mut player, &mut session, &items),
+            BedrockProtocol::RequestChunkRadiusPacket(packet) => handle_request_chunk_radius(ev.entity, packet, &mut player, &mut session, &items, &mut chunk_radius_writer),
             BedrockProtocol::SetLocalPlayerAsInitializedPacket(packet) => handle_set_local_player_as_initialized(packet, &player, &mut session, &mut state_writer),
             packet => {
                 let count = session.unhandled_packets.entry(packet.as_ref().meta().name).or_insert(0);
@@ -183,12 +190,21 @@ pub fn handle_setup(
     }
 }
 
-fn handle_request_chunk_radius(packet: &<BedrockProtocol as ProtoVersionPackets>::RequestChunkRadiusPacket, player: &mut Player, session: &mut Session, items: &ItemRegistry) {
+fn handle_request_chunk_radius(
+    entity: Entity,
+    packet: &<BedrockProtocol as ProtoVersionPackets>::RequestChunkRadiusPacket,
+    player: &mut Player,
+    session: &mut Session,
+    items: &ItemRegistry,
+    chunk_radius_writer: &mut MessageWriter<PlayerChunkRadiusMessage>,
+) {
     let radius = packet.chunk_radius.min(8);
     debug!("RequestChunkRadius: requested={}, capped={}", packet.chunk_radius, radius);
 
     // the queue itself is filled by update_chunk_order, which also keeps it following the player
     player.chunks_radius = radius;
+
+    chunk_radius_writer.write(PlayerChunkRadiusMessage { entity, radius });
 
     session.send(BedrockProtocol::ChunkRadiusUpdatedPacket(ChunkRadiusUpdatedPacket { chunk_radius: radius }.into()));
 

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -15,13 +15,14 @@ use crate::network::handler::setup::PlayerChunkRadiusMessage;
 use crate::network::handler::resource::ResourcePackResponseMessage;
 use crate::network::handler::{PacketHandlers, PacketReceivedMessage};
 use crate::network::login::auth::LoginAuthOIDC;
-use crate::network::session::Session;
 use crate::network::session::state::SessionStateChangedMessage;
+use crate::network::session::{PlayerDisconnectMessage, PlayerKickedMessage, Session, detect_session_close};
 use bedrock::network::connection::Connection;
 use bedrock::network::listener::Listener;
 use bedrock::protocol::{ProtoVersion, Unknown};
 use bevy_app::{App, Last, Plugin, PostUpdate, PreUpdate, Startup};
 use bevy_ecs::prelude::*;
+use bevy_ecs::schedule::IntoScheduleConfigs;
 use crossbeam_channel::Receiver;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::str::FromStr;
@@ -43,6 +44,7 @@ impl Plugin for Network {
             .add_plugins(LoginAuthOIDC)
             .add_systems(Startup, Network::init)
             .add_systems(PreUpdate, Network::receive)
+            .add_systems(PostUpdate, detect_session_close.before(Network::flush))
             .add_systems(PostUpdate, Network::flush)
             .add_systems(Last, BandwidthTracker::sample)
             .init_resource::<BandwidthTracker>()
@@ -50,6 +52,8 @@ impl Plugin for Network {
             .add_message::<SessionStateChangedMessage>()
             .add_message::<PlayerJoinedMessage>()
             .add_message::<PlayerQuitMessage>()
+            .add_message::<PlayerKickedMessage>()
+            .add_message::<PlayerDisconnectMessage>()
             .add_message::<PlayerLoginMessage>()
             .add_message::<PlayerPreLoginMessage>()
             .add_message::<PlayerChunkRadiusMessage>()

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -3,13 +3,13 @@ use crate::config::Config;
 use crate::level::{BlockUpdatedMessage, LevelEventMessage, LevelSoundMessage};
 use crate::network::BedrockProtocol;
 use crate::network::bandwidth::BandwidthTracker;
-use crate::network::handler::block::{BlockBreakMessage, BlockPlaceMessage};
+use crate::network::handler::block::{BlockBreakMessage, BlockPlaceMessage, PlayerDropItemMessage};
 use crate::network::handler::chat::{BroadcastMessage, PlayerChatMessage};
 use crate::network::handler::chunks::ChunkSentMessage;
 use crate::network::handler::form::FormResponseMessage;
 use crate::network::handler::inventory::{InventoryCloseMessage, InventoryOpenMessage, PlayerItemHeldMessage};
 use crate::network::handler::login::PlayerLoginMessage;
-use crate::network::handler::play::{PlayerJoinedMessage, PlayerJumpMessage, PlayerMoveMessage, PlayerQuitMessage, PlayerToggleFlightMessage, PlayerToggleSneakMessage, PlayerToggleSprintMessage};
+use crate::network::handler::play::{PlayerItemUseMessage, PlayerJoinedMessage, PlayerJumpMessage, PlayerMoveMessage, PlayerQuitMessage, PlayerToggleFlightMessage, PlayerToggleSneakMessage, PlayerToggleSprintMessage};
 use crate::network::handler::request::PlayerPreLoginMessage;
 use crate::network::handler::resource::ResourcePackResponseMessage;
 use crate::network::handler::setup::PlayerChunkRadiusMessage;
@@ -62,10 +62,12 @@ impl Plugin for Network {
             .add_message::<PlayerToggleSprintMessage>()
             .add_message::<PlayerToggleFlightMessage>()
             .add_message::<PlayerJumpMessage>()
+            .add_message::<PlayerItemUseMessage>()
             .add_message::<ResourcePackResponseMessage>()
             .add_message::<BlockUpdatedMessage>()
             .add_message::<BlockBreakMessage>()
             .add_message::<BlockPlaceMessage>()
+            .add_message::<PlayerDropItemMessage>()
             .add_message::<InventoryOpenMessage>()
             .add_message::<InventoryCloseMessage>()
             .add_message::<PlayerItemHeldMessage>()

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -3,13 +3,15 @@ use crate::config::Config;
 use crate::level::{BlockUpdatedMessage, LevelEventMessage, LevelSoundMessage};
 use crate::network::BedrockProtocol;
 use crate::network::bandwidth::BandwidthTracker;
-use crate::network::handler::block::{BlockBreakMessage, BlockPlaceMessage, PlayerDropItemMessage};
+use crate::network::handler::block::{BlockBreakMessage, BlockInteractMessage, BlockPlaceMessage, PlayerDropItemMessage};
 use crate::network::handler::chat::{BroadcastMessage, PlayerChatMessage};
 use crate::network::handler::chunks::ChunkSentMessage;
 use crate::network::handler::form::FormResponseMessage;
 use crate::network::handler::inventory::{InventoryCloseMessage, InventoryOpenMessage, PlayerItemHeldMessage};
 use crate::network::handler::login::PlayerLoginMessage;
-use crate::network::handler::play::{PlayerItemUseMessage, PlayerJoinedMessage, PlayerJumpMessage, PlayerMoveMessage, PlayerQuitMessage, PlayerToggleFlightMessage, PlayerToggleSneakMessage, PlayerToggleSprintMessage};
+use crate::network::handler::play::{
+    PlayerItemUseMessage, PlayerJoinedMessage, PlayerJumpMessage, PlayerMoveMessage, PlayerQuitMessage, PlayerToggleFlightMessage, PlayerToggleSneakMessage, PlayerToggleSprintMessage,
+};
 use crate::network::handler::request::PlayerPreLoginMessage;
 use crate::network::handler::resource::ResourcePackResponseMessage;
 use crate::network::handler::setup::PlayerChunkRadiusMessage;
@@ -68,6 +70,7 @@ impl Plugin for Network {
             .add_message::<BlockBreakMessage>()
             .add_message::<BlockPlaceMessage>()
             .add_message::<PlayerDropItemMessage>()
+            .add_message::<BlockInteractMessage>()
             .add_message::<InventoryOpenMessage>()
             .add_message::<InventoryCloseMessage>()
             .add_message::<PlayerItemHeldMessage>()

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -9,10 +9,10 @@ use crate::network::handler::chunks::ChunkSentMessage;
 use crate::network::handler::form::FormResponseMessage;
 use crate::network::handler::inventory::{InventoryCloseMessage, InventoryOpenMessage, PlayerItemHeldMessage};
 use crate::network::handler::login::PlayerLoginMessage;
-use crate::network::handler::play::{PlayerJoinedMessage, PlayerMoveMessage, PlayerQuitMessage};
+use crate::network::handler::play::{PlayerJoinedMessage, PlayerMoveMessage, PlayerQuitMessage, PlayerToggleFlightMessage, PlayerToggleSneakMessage, PlayerToggleSprintMessage};
 use crate::network::handler::request::PlayerPreLoginMessage;
-use crate::network::handler::setup::PlayerChunkRadiusMessage;
 use crate::network::handler::resource::ResourcePackResponseMessage;
+use crate::network::handler::setup::PlayerChunkRadiusMessage;
 use crate::network::handler::{PacketHandlers, PacketReceivedMessage};
 use crate::network::login::auth::LoginAuthOIDC;
 use crate::network::session::state::SessionStateChangedMessage;
@@ -58,6 +58,9 @@ impl Plugin for Network {
             .add_message::<PlayerPreLoginMessage>()
             .add_message::<PlayerChunkRadiusMessage>()
             .add_message::<PlayerMoveMessage>()
+            .add_message::<PlayerToggleSneakMessage>()
+            .add_message::<PlayerToggleSprintMessage>()
+            .add_message::<PlayerToggleFlightMessage>()
             .add_message::<ResourcePackResponseMessage>()
             .add_message::<BlockUpdatedMessage>()
             .add_message::<BlockBreakMessage>()

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -5,11 +5,13 @@ use crate::network::BedrockProtocol;
 use crate::network::bandwidth::BandwidthTracker;
 use crate::network::handler::block::{BlockBreakMessage, BlockPlaceMessage};
 use crate::network::handler::chat::{BroadcastMessage, PlayerChatMessage};
+use crate::network::handler::chunks::ChunkSentMessage;
 use crate::network::handler::form::FormResponseMessage;
 use crate::network::handler::inventory::{InventoryCloseMessage, InventoryOpenMessage, PlayerItemHeldMessage};
 use crate::network::handler::login::PlayerLoginMessage;
 use crate::network::handler::play::{PlayerJoinedMessage, PlayerMoveMessage, PlayerQuitMessage};
 use crate::network::handler::request::PlayerPreLoginMessage;
+use crate::network::handler::setup::PlayerChunkRadiusMessage;
 use crate::network::handler::resource::ResourcePackResponseMessage;
 use crate::network::handler::{PacketHandlers, PacketReceivedMessage};
 use crate::network::login::auth::LoginAuthOIDC;
@@ -50,6 +52,7 @@ impl Plugin for Network {
             .add_message::<PlayerQuitMessage>()
             .add_message::<PlayerLoginMessage>()
             .add_message::<PlayerPreLoginMessage>()
+            .add_message::<PlayerChunkRadiusMessage>()
             .add_message::<PlayerMoveMessage>()
             .add_message::<ResourcePackResponseMessage>()
             .add_message::<BlockUpdatedMessage>()
@@ -59,6 +62,7 @@ impl Plugin for Network {
             .add_message::<InventoryCloseMessage>()
             .add_message::<PlayerItemHeldMessage>()
             .add_message::<FormResponseMessage>()
+            .add_message::<ChunkSentMessage>()
             .add_message::<PlayerChatMessage>()
             .add_message::<CommandPreprocessMessage>()
             .add_message::<CommandRequestedMessage>()

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -9,7 +9,7 @@ use crate::network::handler::chunks::ChunkSentMessage;
 use crate::network::handler::form::FormResponseMessage;
 use crate::network::handler::inventory::{InventoryCloseMessage, InventoryOpenMessage, PlayerItemHeldMessage};
 use crate::network::handler::login::PlayerLoginMessage;
-use crate::network::handler::play::{PlayerJoinedMessage, PlayerMoveMessage, PlayerQuitMessage, PlayerToggleFlightMessage, PlayerToggleSneakMessage, PlayerToggleSprintMessage};
+use crate::network::handler::play::{PlayerJoinedMessage, PlayerJumpMessage, PlayerMoveMessage, PlayerQuitMessage, PlayerToggleFlightMessage, PlayerToggleSneakMessage, PlayerToggleSprintMessage};
 use crate::network::handler::request::PlayerPreLoginMessage;
 use crate::network::handler::resource::ResourcePackResponseMessage;
 use crate::network::handler::setup::PlayerChunkRadiusMessage;
@@ -61,6 +61,7 @@ impl Plugin for Network {
             .add_message::<PlayerToggleSneakMessage>()
             .add_message::<PlayerToggleSprintMessage>()
             .add_message::<PlayerToggleFlightMessage>()
+            .add_message::<PlayerJumpMessage>()
             .add_message::<ResourcePackResponseMessage>()
             .add_message::<BlockUpdatedMessage>()
             .add_message::<BlockBreakMessage>()

--- a/src/network/session/mod.rs
+++ b/src/network/session/mod.rs
@@ -11,7 +11,7 @@ use bedrock::protocol::v662::enums::PlayStatus;
 use bedrock::protocol::v662::packets::PlayStatusPacket;
 use bedrock::protocol::v712::packets::{DisconnectMessage, DisconnectPacket};
 use bedrock::protocol::v1001::enums::ConnectionFailReason;
-use bevy_ecs::prelude::{Component, Entity, MessageWriter};
+use bevy_ecs::prelude::{Component, Entity, Message, MessageWriter, Query};
 use std::collections::HashMap;
 use std::mem::take;
 use std::sync::Arc;
@@ -34,11 +34,24 @@ enum ConnectionStep {
     Recv(Result<Vec<u8>, ConnectionError>),
 }
 
+#[derive(Message, Clone, Debug)]
+pub struct PlayerKickedMessage {
+    pub entity: Entity,
+    pub reason: String,
+}
+
+#[derive(Message, Clone, Debug)]
+pub struct PlayerDisconnectMessage {
+    pub entity: Entity,
+}
+
 #[derive(Component)]
 pub struct Session {
     entity: Entity,
 
     closed: bool,
+    close_reason: Option<String>,
+    close_notified: bool,
     state: SessionState,
 
     out_q: Vec<BedrockProtocol>,
@@ -132,6 +145,8 @@ impl Session {
             entity,
 
             closed: false,
+            close_reason: None,
+            close_notified: false,
 
             state: SessionState::Request,
 
@@ -218,6 +233,8 @@ impl Session {
                 }
                 .into(),
             ));
+
+            self.close_reason = Some(reason.to_string());
         }
 
         self.closed = true;
@@ -225,6 +242,15 @@ impl Session {
 
     pub fn is_closed(&self) -> bool {
         self.closed
+    }
+
+    fn take_close_event(&mut self) -> Option<Option<String>> {
+        if !self.closed || self.close_notified {
+            return None;
+        }
+
+        self.close_notified = true;
+        Some(self.close_reason.take())
     }
 
     pub fn on_login_success(&mut self) {
@@ -246,5 +272,19 @@ impl Session {
 impl Drop for Session {
     fn drop(&mut self) {
         self.conn_task.abort();
+    }
+}
+
+pub fn detect_session_close(mut sessions: Query<(Entity, &mut Session)>, mut kick_writer: MessageWriter<PlayerKickedMessage>, mut disconnect_writer: MessageWriter<PlayerDisconnectMessage>) {
+    for (entity, mut session) in sessions.iter_mut() {
+        match session.take_close_event() {
+            Some(Some(reason)) => {
+                kick_writer.write(PlayerKickedMessage { entity, reason });
+            }
+            Some(None) => {
+                disconnect_writer.write(PlayerDisconnectMessage { entity });
+            }
+            None => {}
+        }
     }
 }


### PR DESCRIPTION
## Summary

Continues the incremental rollout of the Message/MessageWriter/MessageReader
event system. This batch adds:

**Session lifecycle**
- `PlayerKickedMessage` / `PlayerDisconnectMessage` - a new `detect_session_close`
  system turns every `Session::close()` call into exactly one of these, without
  touching any of the 5 existing `close()` call sites. Scheduled `.before(Network::flush)`
  since flush despawns the closed entity in the same `PostUpdate` stage.

**Movement**
- `PlayerToggleSneakMessage`, `PlayerToggleSprintMessage`, `PlayerToggleFlightMessage` -
  sourced from `PlayerAuthInputPacket`'s edge-triggered Start*/Stop* input flags
  (verified against the actual bedrock-rs v2168 packet definition, where
  `input_data` is `Vec<PlayerAuthInputData>`, not a bitmask like older protocol
  versions).
- `PlayerJumpMessage` - same edge-triggered sourcing (`StartJumping`), but not a
  toggle since a jump is a single instantaneous action.

**Item interaction**
- `PlayerDropItemMessage` - emitted from `handle_block_actions` for
  `PlayerActionType::DropItem`, the same `player_block_actions` pipeline already
  used for break/place. Carries the item read from the player's own held slot
  (server-authoritative), not anything the packet claims.
- `PlayerItemUseMessage` - emitted from the edge-triggered `StartUsingItem` input
  flag (eating, drawing a bow, raising a shield, etc.), same sourcing pattern as
  the movement toggles.
- `BlockInteractMessage` - emitted from `PlayerActionType::InteractWithBlock`.
  Only reports that an interaction was requested - no door/chest/crafting table
  behavior exists yet in this codebase, so nothing currently reacts to it beyond
  the event itself.

**Skipped (documented, not silently dropped)**
- `PlayerItemConsumeMessage` - item consumption arrives via
  `ItemStackRequestActionType::Consume`, part of the item-stack-request system
  chorus cannot decode yet (same limitation as `InventoryTransactionMessage`).
- `PlayerTeleportMessage` - no teleport mechanism exists anywhere in the codebase
  yet (no `/tp`, no server-initiated move), so there is nothing real to hook the
  event to.

All new events are post-events / edge-triggered signals, not cancellable yet -
hook points for future consumers, following the established co-location
convention (event struct next to the system that produces it, registered
centrally in `network.rs`).

## Related issues

<!-- Fixes/Closes: #<issue-number> if there's an open issue for this -->

## Type of change

- Feature

## Checklist

- [x] My code follows the project style (ran `cargo fmt`)
- [x] I ran `cargo clippy` and addressed warnings where appropriate
- [ ] I added tests for new behavior (not applicable - no test suite in this repo yet)
- [x] All CI checks pass
- [ ] I updated relevant documentation (not applicable)

## Test Plan

Ran the server locally and verified sneaking, sprinting, flying, jumping,
dropping items, using items, interacting with blocks, and both kicked and
disconnected sessions all behave exactly as before - this PR only exposes
existing logic as events, it does not change observable behavior. Confirmed
via `cargo check`/`cargo fmt --check`/`cargo clippy` that everything compiles,
is formatted, and lints cleanly.

## Notes for reviewers

The `detect_session_close` scheduling (`.before(Network::flush)`) is the part
most worth a close look - it's the only change in this batch that touches
system ordering rather than just adding a new message + writer call.